### PR TITLE
Coding Abend links

### DIFF
--- a/themes/hugo-graphite/layouts/events/list.html
+++ b/themes/hugo-graphite/layouts/events/list.html
@@ -19,14 +19,14 @@
           <div class="sectionTitle"><a href="#">Coding Abend</a></div>
       
           <div class="event">
-            <div class="eventTitle"><a href="{{ .Params.event_url }}">Jeden Donnerstag</a></div>
+            <div class="eventTitle">Jeden Donnerstag</div>
             <div class="eventDetails">
-              Offener Abend für alle, die Lust haben, an ihren Projekten zu arbeiten.
+              Offener Abend für alle, die Lust haben, an ihren Projekten zu arbeiten und sich mit der Community auszutauschen.
             </div>
           </div>
 
           <div class="event">
-            <div class="eventTitle"><a href="{{ .Params.event_url }}">Und Jeden ersten Donnerstag im Monat</a></div>
+            <div class="eventTitle">Und jeden ersten Donnerstag im Monat</div>
             <div class="eventDetails">
               Ist Premium-Coding Abend. Hier gibt es neben spannenden Themen und kurzen Vorstellungen
               auch noch gemeinsames Essen und Trinken.


### PR DESCRIPTION
Remove link from the Coding Abend cards on the right column of the events page
Add more about community at the Coding Abend