### PR TITLE
Calendar end dates

### DIFF
--- a/themes/hugo-graphite/layouts/partials/calendar.html
+++ b/themes/hugo-graphite/layouts/partials/calendar.html
@@ -12,12 +12,16 @@
   </table>
 <script>
     const formatDate = (date) => {
+        if (date.isDate) {
+            date.addDuration(new ICAL.Duration({days: -1}))
+        }
+
         let result = `${date.year}-${("00"+date.month).slice(-2)}-${("00"+date.day).slice(-2)}`;
         if (!date.isDate) {
             result += ` ${("00"+date.hour).slice(-2)}:${("00"+date.minute).slice(-2)}:${("00"+date.second).slice(-2)}`;
         }
         return result;
-    }
+    };
 
     (async () => {
         const eventsBody = document.getElementById('events');

--- a/themes/hugo-graphite/layouts/partials/calendar.html
+++ b/themes/hugo-graphite/layouts/partials/calendar.html
@@ -2,29 +2,23 @@
     <thead>
     <tr>
     <th>Event</th>
-    <th>Date</th>
+    <th>Start</th>
+    <th>Ende</th>
     <th>Location</th>
     </tr>
     </thead>
     <tbody id="events">
-      {{ $taxo := "author" }}
-      {{ range sort (where $.Site.RegularPages "Section" "events") ".Date" }}
-      {{ if ge (time .Date).Unix now.Unix }}
-      <tr>
-        <td><a href="{{ .Params.event_url }}">{{ .Title | markdownify }}</a></td>
-        <td>{{ partial "pretty_date_ranges" . }}</td>
-        <td>{{ with .Params.description }}{{ . | markdownify }}{{ end }}</td>
-        <td>
-          {{ with .Params.location }}
-            {{ .name  }}
-          {{ end }}
-        </td>
-      </tr>
-        {{ end }}
-      {{ end }}
     </tbody>
   </table>
 <script>
+    const formatDate = (date) => {
+        let result = `${date.year}-${("00"+date.month).slice(-2)}-${("00"+date.day).slice(-2)}`;
+        if (!date.isDate) {
+            result += ` ${("00"+date.hour).slice(-2)}:${("00"+date.minute).slice(-2)}:${("00"+date.second).slice(-2)}`;
+        }
+        return result;
+    }
+
     (async () => {
         const eventsBody = document.getElementById('events');
         const icalUrl = "{{ .Param "calendar.ical_url" }}";
@@ -36,7 +30,7 @@
         const component = new ICAL.Component(jcalData);
         const events = component.getAllSubcomponents("vevent")
             .map((event) => new ICAL.Event(event))
-            .filter((event) => event.isRecurring() || event.startDate.toUnixTime()*1000 > today.getTime())
+            .filter((event) => event.isRecurring() || (event.endDate && event.endDate.toUnixTime()*1000 > today.getTime()) || event.startDate.toUnixTime()*1000 > today.getTime())
             .flatMap((event) => {
                 if (!event.isRecurring()) {
                     return [event];
@@ -61,6 +55,21 @@
                         second: next.second,
                         isDate: next.isDate,
                     });
+                    if (nextEvent.endDate) {
+                        const nextEnd = next.clone();
+                        nextEnd.addDuration(event.duration);
+
+                        nextEvent.endDate = new ICAL.Time({
+                            year: nextEnd.year,
+                            month: nextEnd.month,
+                            day: nextEnd.day,
+                            hour: nextEnd.hour,
+                            minute: nextEnd.minute,
+                            second: nextEnd.second,
+                            isDate: nextEnd.isDate,
+                        })
+                    }
+
                     eventInstances.push(nextEvent);
                 }
 
@@ -70,17 +79,16 @@
             .map((event) => {
                 const row = document.createElement("tr");
                 const eventName = document.createElement("td");
-                const dateCol = document.createElement("td");
+                const startCol = document.createElement("td");
+                const endCol = document.createElement("td");
                 const location = document.createElement("td");
 
                 eventName.innerText = event.summary;
-                dateCol.innerText = `${event.startDate.year}-${("00"+event.startDate.month).slice(-2)}-${("00"+event.startDate.day).slice(-2)}`;
-                if (!event.startDate.isDate) {
-                    dateCol.innerText += ` ${("00"+event.startDate.hour).slice(-2)}:${("00"+event.startDate.minute).slice(-2)}:${("00"+event.startDate.second).slice(-2)}`;
-                }
+                startCol.innerText = formatDate(event.startDate);
+                endCol.innerText = formatDate(event.endDate);
                 location.innerText = event.location;
 
-                row.append(eventName, dateCol, location);
+                row.append(eventName, startCol, endCol, location);
                 return row;
             });
         eventsBody.append(...events);

--- a/themes/hugo-graphite/layouts/partials/calendar.html
+++ b/themes/hugo-graphite/layouts/partials/calendar.html
@@ -28,7 +28,6 @@
         const icalUrl = "{{ .Param "calendar.ical_url" }}";
         const today = new Date();
         const dateCutoff = new Date(new Date(today).setMonth(today.getMonth() + {{ .Param "calendar.lookahead_months" }}));
-        console.log(dateCutoff);
         const icalContent = await fetch(icalUrl).then(response => response.text());
         const jcalData = ICAL.parse(icalContent);
         const component = new ICAL.Component(jcalData);
@@ -43,7 +42,6 @@
                 const iterator = event.iterator(event.startDate);
                 const eventInstances = [];
 
-                console.log(event.summary);
                 for (let next = iterator.next(); next && (next.toUnixTime()*1000 < dateCutoff.getTime()); next = iterator.next()) {
                     if (next.toUnixTime()*1000 < today.getTime()) {
                         continue


### PR DESCRIPTION
Split date column into start and end
Remove template content that doesn't get rendered anyway Filter events based on end date first, so events in progress are still shown